### PR TITLE
tweak: add reference to lens-box

### DIFF
--- a/src/usage/lenses/community.md
+++ b/src/usage/lenses/community.md
@@ -4,6 +4,8 @@ Spyglass has a small community that has been building lenses for different topic
 You can check out the ones available to download by clicking on "Manage/install lenses"
 from the menubar icon to open up the "Lens Manager" as seen below.
 
+Community lenses are downloaded from [spyglass-search/lens-box](https://github.com/spyglass-search/lens-box).
+
 ![Lens manager](./../../assets/lens-manager.png)
 
 From here, you can one-click install lenses and the crawler will happily go out and


### PR DESCRIPTION
Hey @a5huynh,

I appreciate your work on this project! I planned on creating a similar project until I stumbled upon spyglass!

This morning, I installed spyglass and realized it was **super** unclear as to where installable lenses are downloaded from. I did not see any reference to lens-box and could not easily locate it from searching through code. I just kept finding functions that called other functions with similar names 😂

Also, I found it confusing that spyglass is not part of the organization while lens-box and the documentation were. It took a while to find the organization repositories since they were stored in separate places. If you plan on keeping spyglass as a personal repository, could you also reference the organization in the README?

Thanks!

### Proposed changes
- Added reference/link to lens-box on the community lens page.

The link is specifically placed above the image so a new reader will quickly see the source. This is where I would have loved to see the reference an hour ago!