### PR TITLE
Fix code highlight 

### DIFF
--- a/src/usage/lenses/build.md
+++ b/src/usage/lenses/build.md
@@ -10,7 +10,7 @@ Here are some examples that I've been personally using:
 Interested in cooking & recipes? Add a `recipe` lens which will go index a
 curated set of websites with high quality recipes.
 
-```
+```rust
 (
     version: "1",
     // Be proud of your creation :). Maybe soon we can share these ;)
@@ -70,7 +70,7 @@ Interested in the Rust programming language? Add the `rustlang` lens which will
 index the Rust book, rust docs, crate.io, and other sites that are related to the
 programming language and not the Rust game / The Rust Belt / oxidation / etc.
 
-```
+```rust
 (
     version: "1",
     author: "Andrew Huynh",

--- a/src/usage/settings.md
+++ b/src/usage/settings.md
@@ -3,7 +3,7 @@
 The `settings.ron` file can be found by "Show Settings folder". If there is no
 file found in their directory on startup, a default one will be created.
 
-```
+```rust
 (
     // The max number of pages to index per domain
     domain_crawl_limit: Finite(1000),


### PR DESCRIPTION
I'm not sure if rust highlighting is the correct one for those snippets, but I just did what was already present in 
`/src/usage/indexing/web.md`